### PR TITLE
[Blood Demon] changed event player_death to a block

### DIFF
--- a/addons/source-python/plugins/es_emulator/eventscripts/wcs/tools/manifest/blood_demon/es_blood_demon.txt
+++ b/addons/source-python/plugins/es_emulator/eventscripts/wcs/tools/manifest/blood_demon/es_blood_demon.txt
@@ -59,7 +59,7 @@ block blooddemon_p90
 	}
 }
 
-event player_death
+block blooddemon_upgrade
 {
 	es wcsgroup get blooddemon_player wcs_tmp2 event_var(attacker)
 	if (server_var(wcs_tmp2) == 1) do


### PR DESCRIPTION
Should be a block instead of player_death function since the function player_kill is used in the race settings.