### PR TITLE
[Eye Ra] Fixed missing setting

### DIFF
--- a/cfg/source-python/wcs/Racepack Holliday - (Version 1.0.5B).ini
+++ b/cfg/source-python/wcs/Racepack Holliday - (Version 1.0.5B).ini
@@ -194,7 +194,7 @@
 		cmd		= "es_xdoblock wcs/tools/holliday/eyera/truth"
 		sfx		= ""
 	[[skill4]]
-        setting  = ""
+        setting  = "|||"
         cmd      = "es_xdoblock wcs/tools/holliday/eyera/summon"
         sfx      = ""
         cooldown = "60|50|45|40"


### PR DESCRIPTION
Skill would not respect cooldown values due to setting being empty.