### PR TITLE
[Nebula] Fixed es_userteam equalto

### DIFF
--- a/addons/source-python/plugins/es_emulator/eventscripts/wcs/tools/holliday/nebula/es_nebula.txt
+++ b/addons/source-python/plugins/es_emulator/eventscripts/wcs/tools/holliday/nebula/es_nebula.txt
@@ -111,8 +111,8 @@ block protostar
 					es wcsgroup set has_used_phoenix event_var(userid) 1
 					if (server_var(wcs_dice) <= server_var(wcs_chance)) do
 					{
-						if (event_var(es_userteam) = 2) then es_xset wcs_team #t
-						if (event_var(es_userteam) = 3) then es_xset wcs_team #ct
+						if (event_var(es_userteam) == 2) then es_xset wcs_team #t
+						if (event_var(es_userteam) == 3) then es_xset wcs_team #ct
 						es wcsgroup get phoenix wcs_phoenix server_var(wcs_team)
 						es_xmath wcs_phoenix + 1
 						es wcsgroup set phoenix server_var(wcs_team) server_var(wcs_phoenix)


### PR DESCRIPTION
Same problem as previously, the skill didn't seem to trigger because of the "=" and "==" issue.
I'll test it again to be sure, but this should be the correct way to use it.

PS: Would be nice to have a feedback, but since it's a player_spawn command I guess it's not possible this way.